### PR TITLE
Force LTR for latex (normal and inline)

### DIFF
--- a/custom.js
+++ b/custom.js
@@ -1,10 +1,22 @@
-const observer = new top.MutationObserver(() => {
-  const allElems = top?.document.querySelectorAll(".ls-block");
-  if (allElems && allElems.length > 0) {
-    for (const elem of allElems) {
-      elem.setAttribute("dir", "auto");
+const setAttributeBySelector = attribute => value => querySelector => {
+  const elements = top?.document.querySelectorAll(querySelector);
+  if (elements && elements.length > 0) {
+    for (const element of elements) {
+      element.setAttribute(attribute, value);
     }
   }
+};
+
+const setDir = setAttributeBySelector("dir");
+const setAuto = setDir("auto");
+const setLTR = setDir("ltr");
+
+const observer = new top.MutationObserver(() => {
+  setAuto(".ls-block");
+  setAuto(".block-properties > div");
+  setLTR(".katex");
+  setLTR(".latex-inline");
+  setAuto(".is-paragraph");
 });
 
 observer.observe(top.document.getElementById("app-container"), {


### PR DESCRIPTION
This patch ensures latex (katex) is always LTR ands sets directions of properties individually.

A few (possibly redundant) helpers are introduced to make everything clearer and let newcomers easily adjust the behavior to their needs.